### PR TITLE
adding karmaExecutable as a parameter

### DIFF
--- a/src/main/java/com/kelveden/karma/StartMojo.java
+++ b/src/main/java/com/kelveden/karma/StartMojo.java
@@ -114,6 +114,9 @@ public class StartMojo extends AbstractMojo {
     @Parameter(property = "karmaFailureIgnore", required = false, defaultValue = "false")
     private Boolean karmaFailureIgnore;
 
+    @Parameter(property = "karmaExecutable", required = false, defaultValue = "karma")
+    private String karmaExecutable;
+
     public void execute() throws MojoExecutionException, MojoFailureException {
 
         if (skipKarma || skipTests) {
@@ -167,9 +170,9 @@ public class StartMojo extends AbstractMojo {
         final ProcessBuilder builder;
 
         if (isWindows()) {
-          builder = new ProcessBuilder("cmd", "/C", "karma", "start", configFile.getAbsolutePath());
+          builder = new ProcessBuilder("cmd", "/C", karmaExecutable, "start", configFile.getAbsolutePath());
         } else {
-          builder = new ProcessBuilder("karma", "start", configFile.getAbsolutePath());
+          builder = new ProcessBuilder(karmaExecutable, "start", configFile.getAbsolutePath());
         }
 
         final List<String> command = builder.command();


### PR DESCRIPTION
The plug-in currently only supports karma being installed globally. In order to support karma being installed in the local node_modules there needs to be an option to pass in the path to the executable. I know the karma documentation says you should install it globally, but that isn't always an option. 
Here is how you'd add the parameter to the plugin configuration:
<karmaExecutable>${project.basedir}/node_modules/.bin/karma</karmaExecutable>
