### PR TITLE
Allow the working directory to be specified.

### DIFF
--- a/src/main/java/com/kelveden/karma/StartMojo.java
+++ b/src/main/java/com/kelveden/karma/StartMojo.java
@@ -44,6 +44,12 @@ public class StartMojo extends AbstractMojo {
     private File configFile;
 
     /**
+     * Path to the working directory.  The working directory should be where node_modules is installed.
+     */
+    @Parameter(defaultValue = "${basedir}", property = "nodeModulePath", required = false)
+    private File workingDirectory;
+
+    /**
      * Comma-separated list of browsers. See the "browsers" section of the Karma online configuration documentation for
      * supported values.
      */
@@ -173,6 +179,10 @@ public class StartMojo extends AbstractMojo {
           builder = new ProcessBuilder("cmd", "/C", karmaExecutable, "start", configFile.getAbsolutePath());
         } else {
           builder = new ProcessBuilder(karmaExecutable, "start", configFile.getAbsolutePath());
+        }
+
+        if(workingDirectory != null) {
+          builder.directory(workingDirectory);
         }
 
         final List<String> command = builder.command();


### PR DESCRIPTION
The maven-karma-plugin will fail to run karma if the karma execution is configured to happen in a submodule.  This is because maven tries to invoke karma at the top-level directory, where node_modules does not exist.  node_modules only exists in the sub-directory, where the submodule is defined.

I've fixed this by setting the working directory of `builder` to be the directory of the submodule.  By default, this is ${basedir}, but it can be overrided in config.  

Thanks!

Ken
