### PR TITLE
make StartMojo thread-safe.

### DIFF
--- a/src/main/java/com/kelveden/karma/StartMojo.java
+++ b/src/main/java/com/kelveden/karma/StartMojo.java
@@ -35,7 +35,11 @@ import java.util.List;
 /**
  * Executes the 'start' task against Karma. See the Karma documentation itself for information: http://karma.github.com.
  */
-@Mojo(name = "start", defaultPhase = LifecyclePhase.TEST)
+@Mojo(
+        name = "start",
+        defaultPhase = LifecyclePhase.TEST,
+        threadSafe = true // see https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3#ParallelbuildsinMaven3-Mojothreadsafetyassertionchecklist
+)
 public class StartMojo extends AbstractMojo {
 
     /**
@@ -173,7 +177,7 @@ public class StartMojo extends AbstractMojo {
         }
 
         postExecution();
-        System.out.flush();
+        AnsiConsole.out.flush();
     }
 
     private void preExecution() throws MojoFailureException {
@@ -235,10 +239,8 @@ public class StartMojo extends AbstractMojo {
         builder.redirectErrorStream(true);
 
         try {
-            AnsiConsole.systemInstall();
-
             getLog().info("Executing Karma Test Suite ...");
-            System.out.println(StringUtils.join(command.iterator(), " "));
+            getLog().info(StringUtils.join(command.iterator(), " "));
 
             return builder.start();
 
@@ -280,7 +282,6 @@ public class StartMojo extends AbstractMojo {
 
     private void resetAnsiConsole() {
         AnsiConsole.out.println("\033[0m ");
-        AnsiConsole.systemInstall();
     }
 
     private void postExecution() {


### PR DESCRIPTION
Hi, thanks for your great plugin. It is very useful for me and my team.

Today I have a suggestion to make your plugin thread-safe. This change lets user uses `-T` option of `mvn` command. Here is [a document](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3#ParallelbuildsinMaven3-Mojothreadsafetyassertionchecklist) which explains requirement to make mojo thread-safe.

In this change there are 2 key points:
- add `threadSafe` parameter to `@Mojo` annotation.
- removing `AnsiConsole.systemInstall()`.
  - It affects `System.out` and `System.err` so other threads will be affected. But this mojo doesn't call `System.out` and `System.err` directly, so I expect that we can remove this method calling.

Thanks in advance,
Kengo TODA
