### PR TITLE
Fixed problem with browser list.

### DIFF
--- a/src/main/java/com/kelveden/karma/StartMojo.java
+++ b/src/main/java/com/kelveden/karma/StartMojo.java
@@ -15,6 +15,14 @@
  */
 package com.kelveden.karma;
 
+import static org.codehaus.plexus.util.StringUtils.join;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.List;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.AbstractMojo;
@@ -25,12 +33,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.StringUtils;
 import org.fusesource.jansi.AnsiConsole;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.List;
 
 /**
  * Executes the 'start' task against Karma. See the Karma documentation itself for information: http://karma.github.com.
@@ -220,6 +222,11 @@ public class StartMojo extends AbstractMojo {
             if (!karmaConfiguration.contains("'" + KARMA_JUNIT_REPORTER_PLUGIN + "'")) {
                 getLog().warn("Could not find the " + KARMA_JUNIT_REPORTER_PLUGIN + " plugin in the supplied configuration file. Test results may be unavailable or incorrect!");
             }
+        }
+
+        if(StringUtils.isNotEmpty(browsers)){
+        	String[] browser = browsers.split("[\\s]*,[\\s]*");
+        	browsers = join(browser, ",");
         }
     }
 


### PR DESCRIPTION
Original problem if we put spaces after comma in the browser list the plugin is not generating the karma command correctly.
e.g in `configuration` if we do 

```
<browsers>PhantomJS, Chrome</browsers>
```

The plugin is not generating the karma process command correctly, and because of that the test on `Chrome` browser is not getting executed and all we see is just a `warning`.
The code fix check for spaces after the comma in the `browsers` list and appropriately construct the correct browser list.
