### PR TITLE
Update maven-plugin-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kelveden</groupId>
     <artifactId>maven-karma-plugin</artifactId>
-    <version>1.8</version>
+    <version>1.8.1</version>
     <packaging>maven-plugin</packaging>
 
     <name>Karma Maven Plugin</name>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.0.4</version>
+            <version>3.3.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
My team has a project that uses maven-karma-plugin.  We specify a language level of Java 1.7.  There is a warning produced during the build from a dependency deep within our dependency tree.

```
Warning:java: Supported source version 'RELEASE_6' from annotation processor 'org.sonatype.guice.bean.scanners.index.SisuIndexAPT6' less than -source '1.7'
```

Current dependency Tree
![screen shot 2016-10-28 at 3 03 56 pm](https://cloud.githubusercontent.com/assets/884240/19823819/d818db48-9d1f-11e6-92d0-42bc5ef28ff3.png)

`SisuIndexAPT6` is the culprit because [it specifies SourceVersion.RELEASE_6](http://grepcode.com/file/repo1.maven.org/maven2/org.sonatype.sisu.inject/guice-bean-scanners/2.3.0/org/sonatype/guice/bean/scanners/index/SisuIndexAPT6.java#102)

The latest maven-plugin-api uses a newer version of this library, which does not specify a language level.  

![screen shot 2016-10-28 at 3 16 04 pm](https://cloud.githubusercontent.com/assets/884240/19824154/010da702-9d22-11e6-9f1d-6764300828a9.png)

Upgrading the dependency allows the library to be run in JVMs greater than 1.6 without warnings.
